### PR TITLE
Don't depend on require_relative

### DIFF
--- a/rubinius.rb
+++ b/rubinius.rb
@@ -1,2 +1,2 @@
-require_relative 'rubinius-2.5.5'
+require File.expand_path('../rubinius-2.5.2', __FILE__)
 Rubinius = Rubinius255


### PR DESCRIPTION
According to the backtrace, this gets required in a `module_eval`. As such, `require_relative` doesn't work for it, and the exception crashes homebrew. This just switches it to use a normal require and the `__FILE__` macro (went with that b/c IDK what versions this needs to support, and `__dir__` is still pretty new).

I copied the diff and pasted it into the GH form, so it's probably right, but you should double check it.

![screenshot 2015-06-03 09 14 38](https://cloud.githubusercontent.com/assets/77495/7963899/4a9ae770-09d2-11e5-8a2a-147e2116c7f9.png)

![screenshot 2015-06-03 09 18 00](https://cloud.githubusercontent.com/assets/77495/7963900/4a9cd300-09d2-11e5-8c43-82673632e58d.png)

![screenshot 2015-06-03 09 15 31](https://cloud.githubusercontent.com/assets/77495/7963898/4a9abe12-09d2-11e5-9262-b0a01ef23dd5.png)
