### PR TITLE
fixes latest version (3.54)

### DIFF
--- a/rubinius.rb
+++ b/rubinius.rb
@@ -2,8 +2,8 @@ require 'formula'
 
 class Rubinius < Formula
   homepage 'http://rubinius.com/'
-  url 'https://rubinius-binaries-rubinius-com.s3.amazonaws.com/homebrew/rubinius-3.54.tar.bz2'
-  sha256 ''
+  url 'https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.54.tar.bz2'
+  sha256 '2498a4c04feafba72d14c12e33ef881ae4bd8d3ccaa9bddcc8aec8acbad780fb'
 
   depends_on 'libyaml'
 


### PR DESCRIPTION
- uses the same URL provided in the [homepage](http://rubinius.com/): https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.54.tar.bz2
- provides the sha256 checksum as per `curl "https://rubinius-releases-rubinius-com.s3.amazonaws.com/rubinius-3.54.tar.bz2" | shasum --algorithm 256 --binary`
