### PR TITLE
Move macOS version requirement to new DSL syntax

### DIFF
--- a/rubinius-2.2.10.rb
+++ b/rubinius-2.2.10.rb
@@ -8,7 +8,7 @@ class Rubinius2210 < Formula
   depends_on 'libyaml'
 
   depends_on :arch => :x86_64
-  depends_on MinimumMacOSRequirement => :mountain_lion
+  depends_on :macos => :yosemite
 
   keg_only "Conflicts with MRI (Matz's Ruby Implementation)."
 

--- a/rubinius-2.3.0.rb
+++ b/rubinius-2.3.0.rb
@@ -8,7 +8,7 @@ class Rubinius230 < Formula
   depends_on 'libyaml'
 
   depends_on :arch => :x86_64
-  depends_on MinimumMacOSRequirement => :mountain_lion
+  depends_on :macos => :yosemite
 
   keg_only "Conflicts with MRI (Matz's Ruby Implementation)."
 

--- a/rubinius-2.4.0.rb
+++ b/rubinius-2.4.0.rb
@@ -8,7 +8,7 @@ class Rubinius240 < Formula
   depends_on 'libyaml'
 
   depends_on :arch => :x86_64
-  depends_on MinimumMacOSRequirement => :mountain_lion
+  depends_on :macos => :yosemite
 
   keg_only "Conflicts with MRI (Matz's Ruby Implementation)."
 

--- a/rubinius-2.4.1.rb
+++ b/rubinius-2.4.1.rb
@@ -8,7 +8,7 @@ class Rubinius241 < Formula
   depends_on 'libyaml'
 
   depends_on :arch => :x86_64
-  depends_on MinimumMacOSRequirement => :mountain_lion
+  depends_on :macos => :yosemite
 
   keg_only "Conflicts with MRI (Matz's Ruby Implementation)."
 

--- a/rubinius-2.5.0.rb
+++ b/rubinius-2.5.0.rb
@@ -8,7 +8,7 @@ class Rubinius250 < Formula
   depends_on 'libyaml'
 
   depends_on :arch => :x86_64
-  depends_on MinimumMacOSRequirement => :mountain_lion
+  depends_on :macos => :yosemite
 
   keg_only "Conflicts with MRI (Matz's Ruby Implementation)."
 

--- a/rubinius-2.5.1.rb
+++ b/rubinius-2.5.1.rb
@@ -8,7 +8,7 @@ class Rubinius251 < Formula
   depends_on 'libyaml'
 
   depends_on :arch => :x86_64
-  depends_on MinimumMacOSRequirement => :mountain_lion
+  depends_on :macos => :yosemite
 
   keg_only "Conflicts with MRI (Matz's Ruby Implementation)."
 

--- a/rubinius-2.5.2.rb
+++ b/rubinius-2.5.2.rb
@@ -8,7 +8,7 @@ class Rubinius252 < Formula
   depends_on 'libyaml'
 
   depends_on :arch => :x86_64
-  depends_on MinimumMacOSRequirement => :mountain_lion
+  depends_on :macos => :yosemite
 
   keg_only "Conflicts with MRI (Matz's Ruby Implementation)."
 

--- a/rubinius-2.5.3.rb
+++ b/rubinius-2.5.3.rb
@@ -8,7 +8,7 @@ class Rubinius253 < Formula
   depends_on 'libyaml'
 
   depends_on :arch => :x86_64
-  depends_on MinimumMacOSRequirement => :mountain_lion
+  depends_on :macos => :yosemite
 
   keg_only "Conflicts with MRI (Matz's Ruby Implementation)."
 

--- a/rubinius-2.5.4.rb
+++ b/rubinius-2.5.4.rb
@@ -8,7 +8,7 @@ class Rubinius254 < Formula
   depends_on 'libyaml'
 
   depends_on :arch => :x86_64
-  depends_on MinimumMacOSRequirement => :mountain_lion
+  depends_on :macos => :yosemite
 
   keg_only "Conflicts with MRI (Matz's Ruby Implementation)."
 

--- a/rubinius-2.5.5.rb
+++ b/rubinius-2.5.5.rb
@@ -8,7 +8,7 @@ class Rubinius255 < Formula
   depends_on 'libyaml'
 
   depends_on :arch => :x86_64
-  depends_on MinimumMacOSRequirement => :mountain_lion
+  depends_on :macos => :yosemite
 
   keg_only "Conflicts with MRI (Matz's Ruby Implementation)."
 

--- a/rubinius-2.5.6.rb
+++ b/rubinius-2.5.6.rb
@@ -8,7 +8,7 @@ class Rubinius256 < Formula
   depends_on 'libyaml'
 
   depends_on :arch => :x86_64
-  depends_on MinimumMacOSRequirement => :mountain_lion
+  depends_on :macos => :yosemite
 
   keg_only "Conflicts with MRI (Matz's Ruby Implementation)."
 

--- a/rubinius-2.5.7.rb
+++ b/rubinius-2.5.7.rb
@@ -8,7 +8,7 @@ class Rubinius257 < Formula
   depends_on 'libyaml'
 
   depends_on :arch => :x86_64
-  depends_on MinimumMacOSRequirement => :mountain_lion
+  depends_on :macos => :yosemite
 
   keg_only "Conflicts with MRI (Matz's Ruby Implementation)."
 

--- a/rubinius-2.5.8.rb
+++ b/rubinius-2.5.8.rb
@@ -8,7 +8,7 @@ class Rubinius258 < Formula
   depends_on 'libyaml'
 
   depends_on :arch => :x86_64
-  depends_on MinimumMacOSRequirement => :mountain_lion
+  depends_on :macos => :yosemite
 
   keg_only "Conflicts with MRI (Matz's Ruby Implementation)."
 

--- a/rubinius-2.7.rb
+++ b/rubinius-2.7.rb
@@ -8,7 +8,7 @@ class Rubinius27 < Formula
   depends_on 'libyaml'
 
   depends_on :arch => :x86_64
-  depends_on MinimumMacOSRequirement => :mountain_lion
+  depends_on :macos => :yosemite
 
   keg_only "Conflicts with MRI (Matz's Ruby Implementation)."
 

--- a/rubinius-2.8.rb
+++ b/rubinius-2.8.rb
@@ -8,7 +8,7 @@ class Rubinius28 < Formula
   depends_on 'libyaml'
 
   depends_on :arch => :x86_64
-  depends_on MinimumMacOSRequirement => :mountain_lion
+  depends_on :macos => :yosemite
 
   keg_only "Conflicts with MRI (Matz's Ruby Implementation)."
 

--- a/rubinius.rb
+++ b/rubinius.rb
@@ -8,7 +8,7 @@ class Rubinius < Formula
   depends_on 'libyaml'
 
   depends_on :arch => :x86_64
-  depends_on MinimumMacOSRequirement => :mountain_lion
+  depends_on :macos => :yosemite
 
   keg_only "Conflicts with MRI (Matz's Ruby Implementation)."
 


### PR DESCRIPTION
Homebrew introduced new macOS version requirement classes and corresponding DSL syntax.

Also, Homebrew doesn't support Mountain Lion anymore, the oldest supported release is Yosemite.

Fixes #10.